### PR TITLE
bugfix: Prevents retries and noisy error messages on auto-blame failure

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,10 +19,7 @@
                 "owner": "typescript",
                 "source": "ts",
                 "applyTo": "closedDocuments",
-                "fileLocation": [
-                    "relative",
-                    "${workspaceFolder}"
-                ],
+                "fileLocation": ["relative", "${workspaceFolder}"],
                 "severity": "error",
                 "pattern": [
                     {
@@ -48,7 +45,7 @@
                         "regexp": "^\\[watch\\] build finished"
                     }
                 }
-            },
+            }
         },
         {
             "type": "npm",
@@ -63,10 +60,7 @@
         },
         {
             "label": "tasks: watch-tests",
-            "dependsOn": [
-                "npm: watch",
-                "npm: watch-tests"
-            ],
+            "dependsOn": ["npm: watch", "npm: watch-tests"],
             "problemMatcher": []
         }
     ]

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
         "compile-tests": "tsc -p . --outDir out",
         "esbuild": "node ./esbuild.config.mjs",
         "eslint": "eslint src --ext ts",
+        "eslint:fix": "eslint src --ext ts --fix",
         "lint": "npm run eslint && npm run prettier",
         "package": "webpack --mode production --devtool hidden-source-map",
         "prepare": "husky",

--- a/src/blamer.ts
+++ b/src/blamer.ts
@@ -118,7 +118,7 @@ export class Blamer {
         return result;
     }
 
-    async showBlameForFile(textEditor?: TextEditor, fileName?: string, autoBlame: boolean = false) {
+    async showBlameForFile(textEditor?: TextEditor, fileName?: string) {
         if (!textEditor || !fileName) {
             this.logger.debug("No editor or file found, aborting...");
             return;
@@ -213,13 +213,13 @@ export class Blamer {
                 return;
             }
 
-            return await this.showBlameForFile(textEditor, fileName, true);
+            return await this.showBlameForFile(textEditor, fileName);
         } catch (err: any) {
             this.statusBarItem.hide();
             this.logger.debug("Blame attemped via auto-blame, silently failing");
 
-            if (fileName && err instanceof NotWorkingCopyError) {
-                await this.setRecordsForFile(fileName, { lines: {}, workingCopy: false });
+            if (err instanceof NotWorkingCopyError) {
+                await this.setRecordsForFile(err.fileName, { lines: {}, workingCopy: false });
             }
         }
     }

--- a/src/blamer.ts
+++ b/src/blamer.ts
@@ -12,6 +12,7 @@ import {
 
 import { EXTENSION_CONFIGURATION, EXTENSION_NAME } from "./const/extension";
 import { DecorationManager } from "./decoration-manager";
+import { NotWorkingCopyError } from "./errors/not-working-copy-error";
 import { Storage } from "./storage";
 import { SVN } from "./svn";
 import { DecorationRecord } from "./types/decoration-record.model";
@@ -158,10 +159,9 @@ export class Blamer {
         try {
             return await this.showBlameForFile(textEditor, fileName);
         } catch (err: any) {
-            const output = err?.message || err;
             this.statusBarItem.hide();
             this.logger.error("Blame action failed", { err });
-            window.showErrorMessage(`${EXTENSION_NAME}: Something went wrong - ${output}`);
+            window.showErrorMessage(`${EXTENSION_NAME}: Something went wrong - ${err?.message}`);
         }
     }
 
@@ -174,10 +174,9 @@ export class Blamer {
                 : await this.showBlameForFile(textEditor, fileName);
         } catch (err: any) {
             const blameAction = fileData ? "hide" : "show";
-            const output = err?.message || err;
             this.statusBarItem.hide();
-            this.logger.error(`Blame action failed [${blameAction}]`, { err });
-            window.showErrorMessage(`${EXTENSION_NAME}: Something went wrong - ${output}`);
+            this.logger.error(`Toggle blame failed [${blameAction}]`, { err });
+            window.showErrorMessage(`${EXTENSION_NAME}: Something went wrong - ${err?.message}`);
         }
     }
 
@@ -218,7 +217,8 @@ export class Blamer {
         } catch (err: any) {
             this.statusBarItem.hide();
             this.logger.debug("Blame attemped via auto-blame, silently failing");
-            if (fileName) {
+
+            if (fileName && err instanceof NotWorkingCopyError) {
                 await this.setRecordsForFile(fileName, { lines: {}, workingCopy: false });
             }
         }

--- a/src/decoration-manager.ts
+++ b/src/decoration-manager.ts
@@ -68,26 +68,29 @@ export class DecorationManager {
     ): Promise<DecorationRecord> {
         const gutterImagePathHashMap = await this.createGutterImagePathHashMap(revisions);
 
-        return blames.reduce<DecorationRecord>((acc, blame) => {
-            const metadata = mapBlameToDecorationData(
-                blame,
-                gutterImagePathHashMap[blame.revision],
-                logs.find(({ revision }) => blame.revision === revision)?.log,
-            );
+        return blames.reduce<Required<DecorationRecord>>(
+            (acc, blame) => {
+                const metadata = mapBlameToDecorationData(
+                    blame,
+                    gutterImagePathHashMap[blame.revision],
+                    logs.find(({ revision }) => blame.revision === revision)?.log,
+                );
 
-            const decoration = this.createAndSetLineDecoration(textEditor, metadata, "blame");
+                const decoration = this.createAndSetLineDecoration(textEditor, metadata, "blame");
 
-            acc[blame.line] = {
-                decoration,
-                metadata,
-            };
+                acc.lines[blame.line] = {
+                    decoration,
+                    metadata,
+                };
 
-            return acc;
-        }, {});
+                return acc;
+            },
+            { lines: {}, workingCopy: true },
+        );
     }
 
     reApplyDecorations(textEditor: TextEditor, records: DecorationRecord) {
-        return Object.values(records).map(({ decoration, metadata }) => {
+        return Object.values(records.lines || {}).map(({ decoration, metadata }) => {
             textEditor?.setDecorations(decoration, mapDecorationOptions(metadata));
         });
     }

--- a/src/decoration-manager.ts
+++ b/src/decoration-manager.ts
@@ -90,7 +90,7 @@ export class DecorationManager {
     }
 
     reApplyDecorations(textEditor: TextEditor, records: DecorationRecord) {
-        return Object.values(records.lines || {}).map(({ decoration, metadata }) => {
+        return Object.values(records.lines).map(({ decoration, metadata }) => {
             textEditor?.setDecorations(decoration, mapDecorationOptions(metadata));
         });
     }

--- a/src/errors/not-working-copy-error.ts
+++ b/src/errors/not-working-copy-error.ts
@@ -1,0 +1,5 @@
+export class NotWorkingCopyError extends Error {
+    constructor(public fileName: string) {
+        super("File is not a working copy");
+    }
+}

--- a/src/svn.ts
+++ b/src/svn.ts
@@ -1,5 +1,6 @@
 import { LogOutputChannel } from "vscode";
 
+import { NotWorkingCopyError } from "./errors/not-working-copy-error";
 import { mapBlameOutputToBlameModel } from "./mapping/map-blame-output-to-blame-model";
 import { mapLogOutputToMessage } from "./mapping/map-log-output-to-message";
 import { Blame } from "./types/blame.model";
@@ -22,11 +23,11 @@ export class SVN {
         } catch (err: any) {
             if (typeof err === "string" && err.includes("E155007")) {
                 this.logger.warn("File is not a working copy, cannot complete action");
-                throw new Error("File is not a working copy");
+                throw new NotWorkingCopyError(fileName);
             }
 
             this.logger.error("Failed to blame file", { err });
-            throw err;
+            throw new Error(err);
         }
     }
 
@@ -50,12 +51,12 @@ export class SVN {
             this.logger.debug("Log child process successful");
 
             return logs;
-        } catch (err) {
+        } catch (err: any) {
             this.logger.error("Failed to to fetch logs for file", {
                 err,
                 logs: revisions.length,
             });
-            throw err;
+            throw new Error(err);
         }
     }
 }

--- a/src/svn.ts
+++ b/src/svn.ts
@@ -20,12 +20,7 @@ export class SVN {
 
             return mapBlameOutputToBlameModel(data);
         } catch (err: any) {
-            if (typeof err === "string" && err.includes("E155007")) {
-                this.logger.warn("File is not a working copy, cannot complete action");
-                throw new Error("File is not a working copy");
-            }
-
-            this.logger.error("Failed to blame file", { err: err?.message });
+            this.logger.error("Failed to blame file", { err });
             throw err;
         }
     }

--- a/src/svn.ts
+++ b/src/svn.ts
@@ -25,7 +25,6 @@ export class SVN {
                 throw new Error("File is not a working copy");
             }
 
-            this.logger.error("Failed to blame file", { err: err?.message });
             this.logger.error("Failed to blame file", { err });
             throw err;
         }

--- a/src/svn.ts
+++ b/src/svn.ts
@@ -20,6 +20,12 @@ export class SVN {
 
             return mapBlameOutputToBlameModel(data);
         } catch (err: any) {
+            if (typeof err === "string" && err.includes("E155007")) {
+                this.logger.warn("File is not a working copy, cannot complete action");
+                throw new Error("File is not a working copy");
+            }
+
+            this.logger.error("Failed to blame file", { err: err?.message });
             this.logger.error("Failed to blame file", { err });
             throw err;
         }

--- a/src/types/decoration-record.model.ts
+++ b/src/types/decoration-record.model.ts
@@ -3,7 +3,7 @@ import { TextEditorDecorationType } from "vscode";
 import { DecorationData } from "./decoration-data.model";
 
 export type DecorationRecord = {
-    lines?: {
+    lines: {
         [key: string]: {
             decoration: TextEditorDecorationType;
             metadata: DecorationData;

--- a/src/types/decoration-record.model.ts
+++ b/src/types/decoration-record.model.ts
@@ -3,8 +3,11 @@ import { TextEditorDecorationType } from "vscode";
 import { DecorationData } from "./decoration-data.model";
 
 export type DecorationRecord = {
-    [key: string]: {
-        decoration: TextEditorDecorationType;
-        metadata: DecorationData;
+    lines?: {
+        [key: string]: {
+            decoration: TextEditorDecorationType;
+            metadata: DecorationData;
+        };
     };
+    workingCopy: boolean;
 };


### PR DESCRIPTION
Resolves #482 

Auto-blame runs a blame on every file as it becomes active†. This means that if you open a file that isn't a "working copy", it will show an error message when it fails to blame. 

This PR does the following:

* Silently swallows errors for auto-blamed files that fail. It won't show any error message popups
* Records the file's working copy "status" so that it doesn't retry every time you go back to the file

**Note: Files that are manually blamed and fail will still show an error message.**


† "active" is defined as when the active text editor changes. This could be clicking in/out, changing tabs, or closing and opening files.