### PR TITLE
bugfix: Blame decorations being recycled across files

### DIFF
--- a/src/blamer.ts
+++ b/src/blamer.ts
@@ -64,7 +64,7 @@ export class Blamer {
         const existingRecord = await this.getRecordForFile(fileName);
         return await this.storage.set<DecorationRecord>(
             fileName,
-            mapToDecorationRecord(merge(existingRecord, update)),
+            merge({}, existingRecord, update),
         );
     }
 
@@ -214,6 +214,9 @@ export class Blamer {
             }
 
             if (existingRecord) {
+                this.logger.debug("Blame already exists for file, re-applying decorations", {
+                    fileName,
+                });
                 this.decorationManager.reApplyDecorations(textEditor, existingRecord);
                 return;
             }

--- a/src/mapping/map-to-decoration-record.ts
+++ b/src/mapping/map-to-decoration-record.ts
@@ -10,4 +10,4 @@ const defaultRecord: DecorationRecord = {
 };
 
 export const mapToDecorationRecord = (record: Partial<DecorationRecord>): DecorationRecord =>
-    merge(defaultRecord, record);
+    merge({}, defaultRecord, record);


### PR DESCRIPTION
`merge` is mutable, and was mutating the previous decoration record for a file